### PR TITLE
fix: `Retry-After` header date formatting according to RFC 9110

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ The `writeHttpMetadata` will set the following headers:
 - `X-RateLimit-Used`: The number of requests used in the current window.
 - `X-RateLimit-Reset`: The time in seconds when the rate limit window resets.
 - `X-RateLimit-Resource`: The resource being rate limited (if provided).
-- `Retry-After`: The time in seconds when the rate limit window resets.
+- `Retry-After`: The timestamp when the rate limit window resets as a UTC string according to RFC 5322.
 
-The `X-RateLimit-Reset` and `Retry-After` headers are the same and represent the time in seconds when the rate limit window resets, the reason to duplicate them is to keep compatibility with the `Retry-After` header that is used by the HTTP standard and consistency with common `X-RateLimit-` headers.
+The `X-RateLimit-Reset` and `Retry-After` headers contain the same timestamp in different formats. `Retry-After` header format is defined in [section 10.2.3 of the RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-10.2.3).
 
 ## License
 

--- a/src/lib/worker-kv-rate-limit.test.ts
+++ b/src/lib/worker-kv-rate-limit.test.ts
@@ -50,7 +50,7 @@ describe(WorkerKVRateLimit.name, () => {
 		expect(headers.get("X-RateLimit-Used")).toBe("0");
 		expect(new Date(Number(headers.get("X-RateLimit-Reset")))).toBeValidDate();
 		expect(headers.get("X-RateLimit-Resource")).toBe("test");
-		expect(new Date(Number(headers.get("Retry-After")))).toBeValidDate();
+		expect(new Date(Date.parse(headers.get("Retry-After") ?? ""))).toBeValidDate();
 	});
 
 	test("#writeHttpMetadata returns new Headers object", async () => {
@@ -64,6 +64,6 @@ describe(WorkerKVRateLimit.name, () => {
 		expect(headers.get("X-RateLimit-Used")).toBe("0");
 		expect(new Date(Number(headers.get("X-RateLimit-Reset")))).toBeValidDate();
 		expect(headers.get("X-RateLimit-Resource")).toBe("test");
-		expect(new Date(Number(headers.get("Retry-After")))).toBeValidDate();
+		expect(new Date(Date.parse(headers.get("Retry-After") ?? ""))).toBeValidDate();
 	});
 });

--- a/src/lib/worker-kv-rate-limit.ts
+++ b/src/lib/worker-kv-rate-limit.ts
@@ -121,7 +121,7 @@ export class WorkerKVRateLimit implements RateLimit {
 		}
 
 		// Standard HTTP header for rate limiting
-		headers.append("Retry-After", result.reset.toString());
+		headers.append("Retry-After", new Date(result.reset).toUTCString());
 
 		return headers;
 	}


### PR DESCRIPTION
`Retry-After` header should contain either number of seconds as a duration or date as a string representation defined in [RFC 5322](https://www.rfc-editor.org/rfc/rfc5322.html#section-3.3).

Current implementation contains number of seconds since Unix epoch which doesn't conform HTTP Semantics [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110)

Let's fix the format. 

See:
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Retry-After
 - https://www.rfc-editor.org/rfc/rfc9110#section-10.2.3