### PR TITLE
fix: handle internal KV rate-limiting error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 	"include": ["src/index.ts"],
 	"compilerOptions": {
 		"outDir": "./build",
-		"types": ["@cloudflare/workers-types"]
+		"types": ["@cloudflare/workers-types"],
+		"lib": ["ES2015"]
 	}
 }


### PR DESCRIPTION
If multiple checks will be made against the same key within one second, KV will return its own rate limiting error.

See https://developers.cloudflare.com/kv/api/write-key-value-pairs/#limits-to-kv-writes-to-the-same-key

> [!CAUTION]
> This is not tested